### PR TITLE
Ignore debugging/test helpers in R build

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@
 ^TODO\.md$
 ^TODO_PSEUDOLABELING_IMPROVEMENTS\.md$
 ^dev-scripts$
+^debug.*\.R$
+^test_.*\.R$


### PR DESCRIPTION
## Summary
- add patterns for debug and test scripts to `.Rbuildignore`

## Testing
- `R CMD build .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685823f55400832d8650b11bffe95770