### PR TITLE
Add lpSolve fallback solver and tests

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -13,6 +13,10 @@ network_simplex_ot_cpp <- function(cost_r, a_r, b_r, eps = 1e-9) {
     .Call(`_manifoldalign_network_simplex_ot_cpp`, cost_r, a_r, b_r, eps)
 }
 
+fallback_network_simplex_ot_cpp <- function(cost_r, a_r, b_r) {
+    .Call(`_manifoldalign_fallback_network_simplex_ot_cpp`, cost_r, a_r, b_r)
+}
+
 partial_ot_mass_rcpp <- function(cost_r, a_r, b_r, mass, eps = 1e-9) {
     .Call(`_manifoldalign_partial_ot_mass_rcpp`, cost_r, a_r, b_r, mass, eps)
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -56,6 +56,19 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// fallback_network_simplex_ot_cpp
+Rcpp::NumericMatrix fallback_network_simplex_ot_cpp(Rcpp::NumericMatrix cost_r, Rcpp::NumericVector a_r, Rcpp::NumericVector b_r);
+RcppExport SEXP _manifoldalign_fallback_network_simplex_ot_cpp(SEXP cost_rSEXP, SEXP a_rSEXP, SEXP b_rSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::NumericMatrix >::type cost_r(cost_rSEXP);
+    Rcpp::traits::input_parameter< Rcpp::NumericVector >::type a_r(a_rSEXP);
+    Rcpp::traits::input_parameter< Rcpp::NumericVector >::type b_r(b_rSEXP);
+    rcpp_result_gen = Rcpp::wrap(fallback_network_simplex_ot_cpp(cost_r, a_r, b_r));
+    return rcpp_result_gen;
+END_RCPP
+}
 // partial_ot_mass_rcpp
 Rcpp::NumericMatrix partial_ot_mass_rcpp(Rcpp::NumericMatrix cost_r, Rcpp::NumericVector a_r, Rcpp::NumericVector b_r, double mass, double eps);
 RcppExport SEXP _manifoldalign_partial_ot_mass_rcpp(SEXP cost_rSEXP, SEXP a_rSEXP, SEXP b_rSEXP, SEXP massSEXP, SEXP epsSEXP) {
@@ -290,6 +303,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_manifoldalign_debug_network_simplex", (DL_FUNC) &_manifoldalign_debug_network_simplex, 3},
     {"_manifoldalign_linear_sim_embed_cpp", (DL_FUNC) &_manifoldalign_linear_sim_embed_cpp, 8},
     {"_manifoldalign_network_simplex_ot_cpp", (DL_FUNC) &_manifoldalign_network_simplex_ot_cpp, 4},
+    {"_manifoldalign_fallback_network_simplex_ot_cpp", (DL_FUNC) &_manifoldalign_fallback_network_simplex_ot_cpp, 3},
     {"_manifoldalign_partial_ot_mass_rcpp", (DL_FUNC) &_manifoldalign_partial_ot_mass_rcpp, 5},
     {"_manifoldalign_compute_edge_distances_cpp", (DL_FUNC) &_manifoldalign_compute_edge_distances_cpp, 2},
     {"_manifoldalign_compute_edge_gradient_cpp", (DL_FUNC) &_manifoldalign_compute_edge_gradient_cpp, 5},

--- a/src/network_simplex_adapter.cpp
+++ b/src/network_simplex_adapter.cpp
@@ -277,100 +277,23 @@ bool NetworkSimplexAdapter::isAvailable() {
 #endif
 }
 
-// Fallback implementation (copy of existing network_simplex_ot)
+// Fallback implementation using lpSolve via the R helper
 namespace fallback {
 
-arma::mat network_simplex_ot(const arma::mat& cost, 
-                              const arma::vec& a, 
+arma::mat network_simplex_ot(const arma::mat& cost,
+                              const arma::vec& a,
                               const arma::vec& b,
-                              double eps) {
-  
-  int n = a.n_elem;
-  int m = b.n_elem;
-  
-  // Initialize transport plan
-  arma::mat P(n, m, arma::fill::zeros);
-  
-  // Create vectors for remaining mass
-  arma::vec a_rem = a;
-  arma::vec b_rem = b;
-  
-  // North-west corner rule initialization
-  int i = 0, j = 0;
-  
-  while (i < n && j < m) {
-    double mass = std::min(a_rem(i), b_rem(j));
-    P(i, j) = mass;
-    a_rem(i) -= mass;
-    b_rem(j) -= mass;
-    
-    if (a_rem(i) < eps) {
-      i++;
-    }
-    if (b_rem(j) < eps) {
-      j++;
-    }
-  }
-  
-  // Dual variables
-  arma::vec u(n, arma::fill::zeros);
-  arma::vec v(m, arma::fill::zeros);
-  
-  // Iterate to improve solution
-  int max_iter = 1000;
-  for (int iter = 0; iter < max_iter; iter++) {
-    bool improved = false;
-    
-    // Find entering variable (most negative reduced cost)
-    double min_reduced_cost = 0;
-    int enter_i = -1, enter_j = -1;
-    
-    for (int i = 0; i < n; i++) {
-      for (int j = 0; j < m; j++) {
-        if (P(i, j) < eps) {  // Non-basic variable
-          double reduced_cost = cost(i, j) - u(i) - v(j);
-          if (reduced_cost < min_reduced_cost - eps) {
-            min_reduced_cost = reduced_cost;
-            enter_i = i;
-            enter_j = j;
-          }
-        }
-      }
-    }
-    
-    // If no negative reduced cost, we're optimal
-    if (enter_i == -1) {
-      break;
-    }
-    
-    // Find cycle and determine leaving variable
-    // This is a simplified version - full implementation would use
-    // a more sophisticated cycle detection algorithm
-    
-    // For now, just add a small amount to maintain feasibility
-    double delta = std::min(a(enter_i) - arma::sum(P.row(enter_i)), 
-                           b(enter_j) - arma::sum(P.col(enter_j)));
-    
-    if (delta > eps) {
-      P(enter_i, enter_j) = delta;
-      improved = true;
-    }
-    
-    // Update dual variables (simplified)
-    for (int i = 0; i < n; i++) {
-      for (int j = 0; j < m; j++) {
-        if (P(i, j) > eps) {
-          v(j) = cost(i, j) - u(i);
-        }
-      }
-    }
-    
-    if (!improved) {
-      break;
-    }
-  }
-  
-  return P;
+                              double /*eps*/) {
+  Rcpp::Environment pkg = Rcpp::Environment::namespace_env("manifoldalign");
+  Rcpp::Function lp_fun = pkg["classical_ot_lp_r"];
+
+  Rcpp::NumericMatrix cost_r = Rcpp::wrap(cost);
+  Rcpp::NumericVector a_r = Rcpp::wrap(a);
+  Rcpp::NumericVector b_r = Rcpp::wrap(b);
+
+  Rcpp::NumericMatrix sol = lp_fun(cost_r, a_r, b_r);
+
+  return Rcpp::as<arma::mat>(sol);
 }
 
 } // namespace fallback

--- a/src/ot_solvers.cpp
+++ b/src/ot_solvers.cpp
@@ -97,6 +97,19 @@ Rcpp::NumericMatrix network_simplex_ot_cpp(Rcpp::NumericMatrix cost_r,
   return Rcpp::wrap(P);
 }
 
+// [[Rcpp::export]]
+Rcpp::NumericMatrix fallback_network_simplex_ot_cpp(Rcpp::NumericMatrix cost_r,
+                                                    Rcpp::NumericVector a_r,
+                                                    Rcpp::NumericVector b_r) {
+  arma::mat cost = Rcpp::as<arma::mat>(cost_r);
+  arma::vec a = Rcpp::as<arma::vec>(a_r);
+  arma::vec b = Rcpp::as<arma::vec>(b_r);
+
+  arma::mat P = fallback::network_simplex_ot(cost, a, b);
+
+  return Rcpp::wrap(P);
+}
+
 // Note: sinkhorn_ot_cpp moved to sinkhorn_unified.cpp for consolidation
 
 // [[Rcpp::export]]

--- a/tests/testthat/test-fallback-lp.R
+++ b/tests/testthat/test-fallback-lp.R
@@ -1,0 +1,30 @@
+library(testthat)
+library(manifoldalign)
+
+skip_if_not_installed("lpSolve")
+
+test_that("lpSolve fallback matches LEMON solver on 3x3 problem", {
+  if (!manifoldalign:::has_lemon_network_simplex()) {
+    skip("LEMON not available")
+  }
+  set.seed(1)
+  cost <- matrix(runif(9), 3, 3)
+  a <- rep(1/3, 3)
+  b <- rep(1/3, 3)
+  sol_lemon <- manifoldalign:::network_simplex_ot_cpp(cost, a, b)
+  sol_lp <- manifoldalign:::fallback_network_simplex_ot_cpp(cost, a, b)
+  expect_equal(sol_lp, sol_lemon, tolerance = 1e-6)
+})
+
+test_that("lpSolve fallback matches on rectangular problem", {
+  if (!manifoldalign:::has_lemon_network_simplex()) {
+    skip("LEMON not available")
+  }
+  set.seed(2)
+  cost <- matrix(runif(12), 3, 4)
+  a <- rep(1/3, 3)
+  b <- rep(1/4, 4)
+  sol_lemon <- manifoldalign:::network_simplex_ot_cpp(cost, a, b)
+  sol_lp <- manifoldalign:::fallback_network_simplex_ot_cpp(cost, a, b)
+  expect_equal(sol_lp, sol_lemon, tolerance = 1e-6)
+})


### PR DESCRIPTION
## Summary
- integrate lpSolve based OT solver as the fallback implementation
- expose fallback solver to R
- test that fallback results match LEMON network simplex

## Testing
- `R CMD INSTALL .` *(fails: `R` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582405ce5c832db2255939ca059d00